### PR TITLE
Fix menu modal component name

### DIFF
--- a/components/MenuModal.tsx
+++ b/components/MenuModal.tsx
@@ -1,17 +1,17 @@
-// components/Sidebar.tsx
-import { View, Text, Pressable, Animated, Dimensions, StyleSheet, Platform } from 'react-native';
+// components/MenuModal.tsx
+import { View, Text, Pressable, Dimensions, StyleSheet, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useEffect } from 'react';
 import { useRouter } from 'expo-router';
 import { supabase } from '@/services/supabase';
 import Modal from 'react-native-modal';
 
-interface MenuPopoverProps {
+interface MenuModalProps {
   isVisible: boolean;
   onClose: () => void;
 }
 
-export default function MenuPopoverProps({ isVisible, onClose }: MenuPopoverProps) {
+export default function MenuModal({ isVisible, onClose }: MenuModalProps) {
   const router = useRouter();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- rename MenuModal component function and props interface for consistency
- remove unused import

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b46002c8832d944d2fa0ca12758f